### PR TITLE
Some fixes to the translation.

### DIFF
--- a/translation/asm/arcade_task.asm
+++ b/translation/asm/arcade_task.asm
@@ -1,0 +1,17 @@
+.psp
+
+.open "build/ULJM05066/arcade_task.bin", 0x098D4700
+
+  ; ----------------------------
+  ; Text positional changes
+  ; ----------------------------
+  .org 0x098D6864 ; Dialog box dimensions at the bottom
+    li    a1,0x2C
+    li    a2,0xC8
+    li    a3,0x188
+    li    t0,0x40
+  .org 0x098D6B58 ; Dialog box text X/Y pos at bottom
+    li    a1,0x37
+    li    a2,0xD4
+
+.close

--- a/translation/asm/eboot_bin.asm
+++ b/translation/asm/eboot_bin.asm
@@ -3,4 +3,34 @@
 .open "build/ULJM05066/EBOOT.BIN", 0x0880326C
 	.org 0x089125F4 ; Reward, Contract Fee Text Position
 		.byte 0x78, 0x00, 0x70, 0x00, 0x78
+  
+  ; ----------------------------
+  ; Clock face and HP/Stam fixes
+  ; ----------------------------
+  .org 0x088EF240 ; Clock face X/Y pos
+    .dh   0x8
+    .dh   0x6
+  .org 0x088EF24C ; Clock hand group X/Y pos
+    .dh   0x22
+    .dh   0x1E
+  .org 0x088EF254 ; HP bar X/Y pos
+    .dh   0x39
+    .dh   0xC
+  .org 0x088EF260 ; Stam bar X/Y pos
+    .dh   0x39
+    .dh   0x15
+
+  ; ----------------------------
+  ; Shelling fixes
+  ; ----------------------------
+    .org 0x088EF2D4 ; Shelling X/Y pos 
+      .dh   0x3C
+      .dh   0x1E
+
+  ; ----------------------------
+  ; Text positional changes
+  ; ----------------------------
+  .org 0x08917D76 ; In-quest chief's wisdom notes title text pos
+    .dh   0x66
+
 .close

--- a/translation/asm/lobby_task.asm
+++ b/translation/asm/lobby_task.asm
@@ -1,9 +1,26 @@
 .psp
 
+strcpy      equ 0x088112E8
+
 .open "build/ULJM05066/lobby_task.bin", 0x098D4700
 	.org 0x98E86E8 ; 4959 memsize
 		lui			a2, 0x2
 		
 	.org 0x98E87E4 ; 4673 memsize
 		ori			a2, v0, 0xD800
+
+  ; ----------------------------
+  ; Full-width text fixes (SJIS)
+  ; ----------------------------
+  ; Quest details (at quest giver)
+  .org 0x98EE238 ; Time Limit
+    addiu   a1,sp,0xA0
+  
+  .org 0x098E9160 ; Reward/Contract
+    lw      a1,0x10(a0)
+    move    a0,s1
+    jal     strcpy
+    nop
+    b       0x098E91A0
+    nop
 .close

--- a/translation/translate.py
+++ b/translation/translate.py
@@ -105,6 +105,7 @@ def translate(build_dir):
 
     injector.buildASM(build_dir, 44, "demo_task")
     injector.buildASM(build_dir, 51, "lobby_task")
+    injector.buildASM(build_dir, 54, "arcade_task")
         
     path = os.path.join("translation", "data")
     if os.path.exists(path):


### PR DESCRIPTION
* Use ASCII instead of full width characters (SJIS) on the quest givers quest details page. 
* Resized training halls dialog box at the bottom to better fit text and size it better to get rid of improper tiling.
* Adjust some HUD elements to better align.
  * Clock face and HP/Stamina bar have been shifted to better positions and properly aligned
  * Shelling graphic shifted upward to align better with bottom clock bracket and centered with the reload/loading textures.
* In-quest chief's wisdom notes title text centered.